### PR TITLE
Support previous command use

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A command-line Pokemon exploration and collection tool built in Go. Explore the 
 ### 🖥️ Interactive Experience
 
 - **REPL Interface**: Command-line interface with persistent state
+- **Command History**: Navigate through previous commands using arrow keys (↑/↓)
 - **Help System**: Built-in command documentation and usage examples
 - **Real-time Feedback**: Immediate responses and error handling
 
@@ -50,6 +51,8 @@ go build
 | `exit` | none | Exit the application |
 
 ## Usage Examples
+
+**Note**: Use the ↑ (up) and ↓ (down) arrow keys to navigate through your command history.
 
 ```bash
 # Start the Pokedex
@@ -135,6 +138,8 @@ Pokedex/
 ### Technical Details
 
 - **Language**: Go 1.24+
+- **Dependencies**: 
+  - `github.com/chzyer/readline` - Enhanced terminal input with command history
 - **API Integration**: RESTful calls to [PokeAPI](https://pokeapi.co/)
 - **Concurrency**: Thread-safe operations with mutex protection
 - **Testing**: Comprehensive test coverage with table-driven tests

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/see-why/Pokedex
 
 go 1.24.3
 
-require (
-	github.com/chzyer/readline v1.5.1 // indirect
-	golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5 // indirect
-)
+require github.com/chzyer/readline v1.5.1
+
+require golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/see-why/Pokedex
 
 go 1.24.3
+
+require (
+	github.com/chzyer/readline v1.5.1 // indirect
+	golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
+github.com/chzyer/readline v1.5.1 h1:upd/6fQk4src78LMRzh5vItIt361/o4uq553V8B5sGI=
+github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
+github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
+golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5 h1:y/woIyUBFbpQGKS0u1aHF/40WUDnek3fPOyD08H5Vng=
+golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
+github.com/chzyer/logex v1.2.1 h1:XHDu3E6q+gdHgsdTPH6ImJMIp436vR6MPtH8gP05QzM=
 github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
 github.com/chzyer/readline v1.5.1 h1:upd/6fQk4src78LMRzh5vItIt361/o4uq553V8B5sGI=
 github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
+github.com/chzyer/test v1.0.0 h1:p3BQDXSxOhOG0P9z6/hGnII4LGiEPOYBhs8asl/fC04=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5 h1:y/woIyUBFbpQGKS0u1aHF/40WUDnek3fPOyD08H5Vng=
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -11,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/chzyer/readline"
 	"github.com/see-why/Pokedex/internal/pokecache"
 )
 
@@ -22,15 +22,29 @@ func main() {
 		caughtPokemon:       make(map[string]Pokemon),
 	}
 
-	scanner := bufio.NewScanner(os.Stdin)
+	// Create readline instance with command history
+	rl, err := readline.New("Pokedex > ")
+	if err != nil {
+		fmt.Printf("Error creating readline: %v\n", err)
+		os.Exit(1)
+	}
+	defer rl.Close()
 
 	for {
-		fmt.Print("Pokedex > ")
-		if !scanner.Scan() {
-			// No more input available (EOF or error)
-			break
+		input, err := rl.Readline()
+		if err != nil {
+			// Handle EOF (Ctrl+C, Ctrl+D) or other errors
+			if err == readline.ErrInterrupt {
+				fmt.Println("\nClosing the Pokedex... Goodbye!")
+				break
+			} else if err == io.EOF {
+				fmt.Println("\nClosing the Pokedex... Goodbye!")
+				break
+			} else {
+				fmt.Printf("Error reading input: %v\n", err)
+				continue
+			}
 		}
-		input := scanner.Text()
 
 		words := cleanInput(input)
 		if len(words) == 0 {


### PR DESCRIPTION
This pull request introduces command history support to the Pokedex CLI, making it easier for users to navigate and reuse previous commands. The main change is the integration of the `github.com/chzyer/readline` package, which replaces the previous input handling and adds arrow-key navigation for command history. Documentation has also been updated to reflect these improvements.

**User Experience Improvements**
* Replaced manual input handling with the `readline` library in `main.go`, enabling command history navigation via arrow keys and improving error handling for EOF and interrupts.
* Updated the interactive experience section and usage examples in `README.md` to describe the new command history feature and arrow key navigation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R22) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R55-R56)

**Dependency Management**
* Added `github.com/chzyer/readline` as a direct dependency in `go.mod` to support enhanced terminal input.
* Documented the new dependency in the technical details section of `README.md`.

**Codebase Updates**
* Removed unused `bufio` import from `main.go` as input handling is now managed by `readline`.
* Added the `readline` import to `main.go`.